### PR TITLE
fixed data and optimization for get house list

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -514,21 +514,45 @@ QBCore.Functions.CreateCallback('qb-phone:server:GetPlayerHouses', function(sour
 				})
 
 				if v.keyholders ~= "null" then
-					v.keyholders = json.decode(v.keyholders)
-					if v.keyholders ~= nil then
-						for f, data in pairs(v.keyholders) do
-							QBCore.Functions.ExecuteSql(false, "SELECT * FROM `players` WHERE `citizenid` = '"..data.."'", function(keyholderdata)
-								if keyholderdata[1] ~= nil then
-									keyholderdata[1].charinfo = json.decode(keyholderdata[1].charinfo)
-									table.insert(MyHouses[k].keyholders, keyholderdata[1])
-								end
-							end)
+				    v.keyholders = json.decode(v.keyholders)
+				    if v.keyholders ~= nil then
+					for f, data in pairs(v.keyholders) do
+					    QBCore.Functions.ExecuteSql(false, "SELECT * FROM `players` WHERE `citizenid` = '"..data.."'", function(keyholderdata)
+						if keyholderdata[1] ~= nil then
+						    keyholderdata[1].charinfo = json.decode(keyholderdata[1].charinfo)
+
+						    local userKeyHolderData = {
+							charinfo = {
+							    firstname = keyholderdata[1].charinfo.firstname,
+							    lastname = keyholderdata[1].charinfo.lastname
+							},
+							citizenid = keyholderdata[1].citizenid,
+							name = keyholderdata[1].name
+						    }
+
+						    table.insert(MyHouses[k].keyholders, userKeyHolderData)
 						end
-					else
-						MyHouses[k].keyholders[1] = Player.PlayerData
+					    end)
 					end
+				    else
+					MyHouses[k].keyholders[1] = {
+						charinfo = {
+							firstname = Player.PlayerData.charinfo.firstname,
+							lastname = Player.PlayerData.charinfo.lastname
+					    	},
+					    	citizenid = Player.PlayerData.citizenid,
+					    	name = Player.PlayerData.name
+						}
+				    end
 				else
-					MyHouses[k].keyholders[1] = Player.PlayerData
+					MyHouses[k].keyholders[1] = {
+						charinfo = {
+					    		firstname = Player.PlayerData.charinfo.firstname,
+					    		lastname = Player.PlayerData.charinfo.lastname
+						},
+						citizenid = Player.PlayerData.citizenid,
+						name = Player.PlayerData.name
+				    	}
 				end
 			end
 				


### PR DESCRIPTION
It's pointless to send all the data in the "player" table to the client side just to see the house list and key holders.
[https://prnt.sc/163irbv](https://prnt.sc/163irbv)


Aside from being unnecessary, I encountered an error sending this data from the server to the client side.
[https://prnt.sc/163io3l](https://prnt.sc/163io3l)


Here is the beginning of the posts we discussed with other developers:
https://discord.com/channels/831626422232678481/854912490788880414/856220351901073459

And the result: 
https://discord.com/channels/831626422232678481/854912490788880414/856237261565853747