### PR TITLE
Minor Patch Update (Invitees not allowed to exit, removal of enter command)

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -22,7 +22,7 @@ local CurrentHouse = nil
 local RamsDone = 0
 local keyholderMenu = {}
 local keyholderOptions = {}
-local p = nil
+local fetchingHouseKeys = false
 
 -- Functions
 
@@ -351,17 +351,21 @@ local function RemoveHouseKey(citizenData)
 end
 
 local function getKeyHolders()
-    if p then return end
-    p = promise.new()
+    if fetchingHouseKeys then return end
+    fetchingHouseKeys = true
+
+    local p = promise.new()
     QBCore.Functions.TriggerCallback('qb-houses:server:getHouseKeyHolders', function(holders)
         p:resolve(holders)
     end,ClosestHouse)
+
     return Citizen.Await(p)
 end
 
 function HouseKeysMenu()
     local holders = getKeyHolders()
-    p = nil
+    fetchingHouseKeys = false
+
     if holders == nil or next(holders) == nil then
         QBCore.Functions.Notify("No key holders found..", "error", 3500)
         CloseMenuFull()

--- a/client/main.lua
+++ b/client/main.lua
@@ -1265,6 +1265,24 @@ CreateThread(function()
                             end
                         end
                     end
+
+                    if IsInside and CurrentHouse ~= nil and not entering then
+                        if POIOffsets ~= nil then
+                            local exitOffset = vector3(Config.Houses[CurrentHouse].coords.enter.x + POIOffsets.exit.x, Config.Houses[CurrentHouse].coords.enter.y + POIOffsets.exit.y, Config.Houses[CurrentHouse].coords.enter.z - Config.MinZOffset + POIOffsets.exit.z + 1.0)
+                            if #(pos - exitOffset) <= 1.5 then
+                                houseMenu = {
+                                    {
+                                        header = "Exit Property",
+                                        params = {
+                                            event = 'qb-houses:client:ExitOwnedHouse',
+                                            args = {}
+                                        }
+                                    }
+                                }
+                                nearLocation = true
+                            end
+                        end
+                    end
                 end
 
                 if IsInside and CurrentHouse ~= nil and not entering and isOwned then

--- a/client/main.lua
+++ b/client/main.lua
@@ -1190,9 +1190,21 @@ CreateThread(function()
                             if #(pos - dist2) <= 1.5 then
                                 houseMenu = {
                                     {
-                                        header = "/enter to enter house",
-                                        isMenuHeader = true,
-                                        params = {}
+                                        header = "House Options",
+                                        isMenuHeader = true, -- Set to true to make a nonclickable title
+                                    },
+                                    {
+                                        header = "Enter Your House",
+                                        params = {
+                                            event = "qb-houses:client:EnterHouse",
+
+                                        }
+                                    },
+                                    {
+                                        header = "Give House Key",
+                                        params = {
+                                            event = "qb-houses:client:giveHouseKey",
+                                        }
                                     }
                                 }
                                 nearLocation = true

--- a/server/main.lua
+++ b/server/main.lua
@@ -83,11 +83,6 @@ QBCore.Commands.Add("addgarage", "Add House Garage (Real Estate Only)", {}, fals
     end
 end)
 
-QBCore.Commands.Add("enter", "Enter House", {}, false, function(source)
-    local src = source
-    TriggerClientEvent('qb-houses:client:EnterHouse', src)
-end)
-
 QBCore.Commands.Add("ring", "Ring The Doorbell", {}, false, function(source)
     local src = source
     TriggerClientEvent('qb-houses:client:RequestRing', src)


### PR DESCRIPTION
* Fixes an issue where invitee cannot leave an owned house.
* Removed file-scope promise to be function scoped
* Removed "/enter" command and made it an option along with giving keys. (#83)


**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? (I cant due to no multiplayer)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
