### PR TITLE
fix(client): Set closest house on enter

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -563,6 +563,7 @@ end
 
 local function enterOwnedHouse(house)
     CurrentHouse = house
+    ClosestHouse = house
     TriggerServerEvent("InteractSound_SV:PlayOnSource", "houses_door_open", 0.25)
     openHouseAnim()
     IsInside = true
@@ -607,6 +608,7 @@ end
 
 local function enterNonOwnedHouse(house)
     CurrentHouse = house
+    ClosestHouse = house
     TriggerServerEvent("InteractSound_SV:PlayOnSource", "houses_door_open", 0.25)
     openHouseAnim()
     IsInside = true


### PR DESCRIPTION
**Describe Pull request**
This fixes mainly the spawning in houses after logging in from the multicharacter, currently without this fix you can't leave or see any set locations

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes (Be honest)
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
