### PR TITLE
Resolves issue with placing decorations

### DIFF
--- a/client/decorate.lua
+++ b/client/decorate.lua
@@ -63,7 +63,7 @@ local function SaveDecorations()
 				if ObjectList then
 					ObjectList[#ObjectList+1] = {hashname = SelObjHash, x = SelObjPos.x, y = SelObjPos.y, z = SelObjPos.z, rotx = SelObjRot.x, roty = SelObjRot.y, rotz = SelObjRot.z, object = SelectedObj, objectId = #ObjectList+1}
 				else
-					ObjectList[1] = {hashname = SelObjHash, x = SelObjPos.x, y = SelObjPos.y, z = SelObjPos.z, rotx = SelObjRot.x, roty = SelObjRot.y, rotz = SelObjRot.z, object = SelectedObj, objectId = #ObjectList+1}
+					ObjectList[1] = {hashname = SelObjHash, x = SelObjPos.x, y = SelObjPos.y, z = SelObjPos.z, rotx = SelObjRot.x, roty = SelObjRot.y, rotz = SelObjRot.z, object = SelectedObj, objectId = 1}
 				end
 			end
 


### PR DESCRIPTION
**Describe Pull request**
There was an issue with decorations when you tried to place them in your house. The issue was giving you the buy prompt twice and on the second time it would throw an error because price would be nil.  The reason it happend was because when it was the first item in ObjectList it tried to add +1 to an undefined table. Now it just sets it to the first position.

**Questions** (please complete the following information):
Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
Does your code fit the style guidelines? **Yes**
Does your PR fit the contribution guidelines? **Yes**