### PR TITLE
Housing Event Issue

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -711,7 +711,7 @@ RegisterNetEvent('qb-houses:client:RequestRing', function()
 end)
 
 AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
-    TriggerServerEvent('qb-houses:client:setHouses')
+    TriggerServerEvent('qb-houses:server:setHouses')
     SetClosestHouse()
     TriggerEvent('qb-houses:client:setupHouseBlips')
     if Config.UnownedBlips then TriggerEvent('qb-houses:client:setupHouseBlips2') end
@@ -1170,7 +1170,7 @@ end)
 
 CreateThread(function()
     Wait(1000)
-    TriggerServerEvent('qb-houses:client:setHouses')
+    TriggerServerEvent('qb-houses:server:setHouses')
     SetClosestHouse()
     TriggerEvent('qb-houses:client:setupHouseBlips')
     if Config.UnownedBlips then TriggerEvent('qb-houses:client:setupHouseBlips2') end


### PR DESCRIPTION
**Describe Pull request**
Found parts of the script trying to call qb-houses:client:setHouses when it should be calling qb-houses:server:setHouses

This may help with #109 where the same house can be purchased multiple times, and the owner not seeing it as being able to be entered. It appe

If your PR is to fix an issue mention that issue here
**Should** Fix issue #109 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
