### PR TITLE
fix(UnlockedHousing): Raids/Unlocked Housing fix

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1016,6 +1016,7 @@ RegisterNetEvent('qb-houses:client:HomeInvasion', function()
                                     TriggerServerEvent('qb-houses:server:lockHouse', false, ClosestHouse)
                                     QBCore.Functions.Notify('It worked the door is now out.', 'success')
                                     TriggerServerEvent('qb-houses:server:SetHouseRammed', true, ClosestHouse)
+                                    TriggerServerEvent('qb-houses:server:SetRamState', false, ClosestHouse)
                                     DoRamAnimation(false)
                                 else
                                     DoRamAnimation(true)
@@ -1299,6 +1300,22 @@ CreateThread(function()
                                         }
                                     }
                                 }
+                                if not Config.Houses[ClosestHouse].locked then
+                                    houseMenu[#houseMenu+1] ={
+                                        header = "Enter Unlocked House",
+                                        params = {
+                                            event = "qb-houses:client:EnterHouse",
+                                        }
+                                    }
+                                    if QBCore.Functions.GetPlayerData().job.name == 'police' then
+                                        houseMenu[#houseMenu+1] ={
+                                            header = "Lock House",
+                                            params = {
+                                                event = "qb-houses:client:ResetHouse",
+                                            }
+                                        }
+                                    end
+                                end
                             end
                         end
                     end


### PR DESCRIPTION
**Describe Pull request**
This pull request makes it so you can enter unlocked/raided houses which was caused by removing the enter command.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
