### PR TITLE
Update for qb-target and polyzone

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -184,7 +184,6 @@ end
 
 RegisterNetEvent('qb-houses:client:setHouseConfig', function(houseConfig)
     Config.Houses = houseConfig
-    QBCore.Debug(Config.Houses)
     if Config.UseTarget then
         DeleteHousesTargets()
         SetHousesEntranceTargets()

--- a/client/main.lua
+++ b/client/main.lua
@@ -1231,25 +1231,10 @@ RegisterNetEvent('qb-houses:client:setLocation', function(data)
         if HasHouseKey then
             if data.id == 'setstash' then
                 TriggerServerEvent('qb-houses:server:setLocation', coords, ClosestHouse, 1)
-                if Config.UseTarget then
-                    DeleteBoxTarget(stashTargetBox)
-                    isInsideStashTarget = false
-                    RegisterStashTarget()
-                end
             elseif data.id == 'setoutift' then
                 TriggerServerEvent('qb-houses:server:setLocation', coords, ClosestHouse, 2)
-                if Config.UseTarget then
-                    DeleteBoxTarget(outfitsTargetBox)
-                    isInsideOutfitsTarget = false
-                    RegisterOutfitsTarget()
-                end
             elseif data.id == 'setlogout' then
                 TriggerServerEvent('qb-houses:server:setLocation', coords, ClosestHouse, 3)
-                if Config.UseTarget then
-                    DeleteBoxTarget(charactersTargetBox)
-                    isInsiteCharactersTarget = false
-                    RegisterCharactersTarget()
-                end
             end
         else
             QBCore.Functions.Notify(Lang:t("error.not_owner"), "error")
@@ -1264,10 +1249,25 @@ RegisterNetEvent('qb-houses:client:refreshLocations', function(house, location, 
         if IsInside then
             if type == 1 then
                 stashLocation = json.decode(location)
+                if Config.UseTarget then
+                    DeleteBoxTarget(stashTargetBox)
+                    isInsideStashTarget = false
+                    RegisterStashTarget()
+                end
             elseif type == 2 then
                 outfitLocation = json.decode(location)
+                if Config.UseTarget then
+                    DeleteBoxTarget(outfitsTargetBox)
+                    isInsideOutfitsTarget = false
+                    RegisterOutfitsTarget()
+                end
             elseif type == 3 then
                 logoutLocation = json.decode(location)
+                if Config.UseTarget then
+                    DeleteBoxTarget(charactersTargetBox)
+                    isInsiteCharactersTarget = false
+                    RegisterCharactersTarget()
+                end
             end
         end
     end

--- a/client/main.lua
+++ b/client/main.lua
@@ -1231,10 +1231,25 @@ RegisterNetEvent('qb-houses:client:setLocation', function(data)
         if HasHouseKey then
             if data.id == 'setstash' then
                 TriggerServerEvent('qb-houses:server:setLocation', coords, ClosestHouse, 1)
+                if Config.UseTarget then
+                    DeleteBoxTarget(stashTargetBox)
+                    isInsideStashTarget = false
+                    RegisterStashTarget()
+                end
             elseif data.id == 'setoutift' then
                 TriggerServerEvent('qb-houses:server:setLocation', coords, ClosestHouse, 2)
+                if Config.UseTarget then
+                    DeleteBoxTarget(outfitsTargetBox)
+                    isInsideOutfitsTarget = false
+                    RegisterOutfitsTarget()
+                end
             elseif data.id == 'setlogout' then
                 TriggerServerEvent('qb-houses:server:setLocation', coords, ClosestHouse, 3)
+                if Config.UseTarget then
+                    DeleteBoxTarget(charactersTargetBox)
+                    isInsiteCharactersTarget = false
+                    RegisterCharactersTarget()
+                end
             end
         else
             QBCore.Functions.Notify(Lang:t("error.not_owner"), "error")

--- a/client/main.lua
+++ b/client/main.lua
@@ -215,7 +215,7 @@ local function RegisterHouseEntranceTarget(id, house)
                             label = Lang:t("menu.enter_unlocked_house"),
                         }
                     end
-                    if QBCore.Functions.GetPlayerData().job.name == 'police' then
+                    if QBCore.Functions.GetPlayerData().job and QBCore.Functions.GetPlayerData().job.name == 'police' then
                         options[#options+1] = {
                             type = "client",
                             event = "qb-houses:client:ResetHouse",

--- a/client/main.lua
+++ b/client/main.lua
@@ -163,7 +163,7 @@ local function RegisterHouseEntranceTarget(id, house)
     Config.Targets[boxName] = {created = true}
 end
 
-local function DeleteHousesEntranceTargets()
+local function DeleteHousesTargets()
     if Config.Targets and next(Config.Targets) then
         for id, _ in pairs(Config.Targets) do
             exports['qb-target']:RemoveZone(id)
@@ -184,8 +184,9 @@ end
 
 RegisterNetEvent('qb-houses:client:setHouseConfig', function(houseConfig)
     Config.Houses = houseConfig
+    QBCore.Debug(Config.Houses)
     if Config.UseTarget then
-        DeleteHousesEntranceTargets()
+        DeleteHousesTargets()
         SetHousesEntranceTargets()
     end
 end)
@@ -887,6 +888,9 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
             RemoveBlip(v)
         end
     end
+    if Config.UseTarget then
+        DeleteHousesTargets()
+    end
 end)
 
 RegisterNetEvent('qb-houses:client:lockHouse', function(bool, house)
@@ -1084,6 +1088,10 @@ RegisterNetEvent('qb-houses:client:refreshBlips', function() -- Refresh unowned 
     for k,v in pairs(UnownedHouseBlips) do RemoveBlip(v) end
     Wait(250)
     TriggerEvent('qb-houses:client:setupHouseBlips2')
+    if Config.UseTarget then
+        DeleteHousesTargets()
+        SetHousesEntranceTargets()
+    end
 end)
 
 RegisterNetEvent('qb-houses:client:SetClosestHouse', function()
@@ -1205,7 +1213,7 @@ end)
 RegisterNetEvent('qb-houses:client:SetRamState', function(bool, house)
     Config.Houses[house].IsRaming = bool
     if Config.UseTarget then
-        DeleteHousesEntranceTargets()
+        DeleteHousesTargets()
         SetHousesEntranceTargets()
     end
 end)
@@ -1213,7 +1221,7 @@ end)
 RegisterNetEvent('qb-houses:client:SetHouseRammed', function(bool, house)
     Config.Houses[house].IsRammed = bool
     if Config.UseTarget then
-        DeleteHousesEntranceTargets()
+        DeleteHousesTargets()
         SetHousesEntranceTargets()
     end
 end)
@@ -1309,6 +1317,16 @@ end)
 RegisterNetEvent('qb-houses:client:KeyholderOptions', function(data)
     optionMenu(data.citizenData)
 end)
+
+RegisterNetEvent('qb-house:client:RefreshHouseTargets', function ()
+    if not Config.UseTarget then
+        return
+    end
+
+    DeleteHousesTargets()
+    SetHousesEntranceTargets()
+end)
+
 -- NUI Callbacks
 
 RegisterNUICallback('HasEnoughMoney', function(data, cb)

--- a/client/main.lua
+++ b/client/main.lua
@@ -53,16 +53,16 @@ local function RegisterHouseExitTarget(id, isOwned)
     }
 
     if isOwned then
-        table.insert(options, {
+        options[#options+1] = {
             type = "client",
             event = "qb-houses:client:FrontDoorCam",
             label = Lang:t("menu.front_camera"),
-        })
-        table.insert(options, {
+        }
+        options[#options+1] = {
             type = "client",
             event = "qb-houses:client:AnswerDoorbell",
             label = Lang:t("menu.open_door"),
-        })
+        }
     end
 
     exports['qb-target']:AddBoxZone(boxName, coords, 2, 1, {
@@ -124,18 +124,18 @@ local function RegisterHouseEntranceTarget(id, house)
                         }
                     }
                     if not house.locked then
-                        table.insert(options, {
+                        options[#options+1] = {
                             type = "client",
                             event = "qb-houses:client:EnterHouse",
                             label = Lang:t("menu.enter_unlocked_house"),
-                        })
+                        }
                     end
                     if QBCore.Functions.GetPlayerData().job.name == 'police' then
-                        table.insert(options, {
+                        options[#options+1] = {
                             type = "client",
                             event = "qb-houses:client:ResetHouse",
                             label = Lang:t("menu.lock_door_police"),
-                        })
+                        }
                     end
                 else
                     options = {}

--- a/config.lua
+++ b/config.lua
@@ -6,6 +6,11 @@ Config.UnownedBlips = false
 
 Config.Houses = {}
 
+-- **** IMPORTANT ****
+-- UseTarget should only be set to true when using qb-target
+Config.UseTarget = false
+Config.Targets = {}
+
 Config.Furniture = {
 	["sofas"] = {
 		label = "Sofas",

--- a/config.lua
+++ b/config.lua
@@ -8,7 +8,7 @@ Config.Houses = {}
 
 -- **** IMPORTANT ****
 -- UseTarget should only be set to true when using qb-target
-Config.UseTarget = false
+Config.UseTarget = GetConvar('UseTarget', 'false') == 'true'
 Config.Targets = {}
 
 Config.Furniture = {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -14,7 +14,10 @@ shared_scripts {
 
 client_scripts {
 	'client/main.lua',
-	'client/decorate.lua'
+	'client/decorate.lua',
+	'@PolyZone/client.lua',
+	'@PolyZone/BoxZone.lua',
+	'@PolyZone/CircleZone.lua',
 }
 
 server_scripts {

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,7 +2,7 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Houses'
-version '1.0.0'
+version '2.0.0'
 
 ui_page 'html/index.html'
 

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -28,7 +28,8 @@ local Translations = {
         ["unlocked"] = "House is unlocked!",
         ["home_invasion"] = "The door is now open.",
         ["lock_invasion"] = "You locked the house again..",
-        ["recieved_key"] = "You have the keys of %{value} recieved!"
+        ["recieved_key"] = "You have the keys of %{value} recieved!",
+        ["house_purchased"] = "You have successfully bought the house!"
     },
     info = {
         ["door_ringing"] = "Someone is ringing the door!",

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -66,6 +66,11 @@ local Translations = {
         ["enter_unlocked_house"] = "Enter Unlocked House",
         ["lock_door_police"] = "Lock Door"
     },
+    target = {
+        ["open_stash"] = "[E] Open Stash",
+        ["outfits"] = "[E] Change Outfits",
+        ["change_character"] = "[E] Change Character",
+    },
     log = {
         ["house_created"] = "House Created:",
         ["house_address"] = "**Address**: %{label}\n\n**Listing Price**: %{price}\n\n**Tier**: %{tier}\n\n**Listing Agent**: %{agent}",

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -22,6 +22,7 @@ local Translations = {
         ["remove_key_from"] = "Keys Have Been Removed From %{firstname} %{lastname}",
         ["already_keys"] = "This person already has the keys of the house!",
         ["something_wrong"] = "Something went wrong try again!",
+        ["nobody_at_door"] = 'There is nobody at the door...'
     },
     success = {
         ["unlocked"] = "House is unlocked!",

--- a/server/main.lua
+++ b/server/main.lua
@@ -236,9 +236,11 @@ RegisterNetEvent('qb-houses:server:buyHouse', function(house)
         MySQL.Async.insert('INSERT INTO player_houses (house, identifier, citizenid, keyholders) VALUES (?, ?, ?, ?)',{house, pData.PlayerData.license, pData.PlayerData.citizenid, json.encode(housekeyholders[house])})
         MySQL.Async.execute('UPDATE houselocations SET owned = ? WHERE name = ?', {1, house})
         TriggerClientEvent('qb-houses:client:SetClosestHouse', src)
+        TriggerClientEvent('qb-house:client:RefreshHouseTargets', src)
         pData.Functions.RemoveMoney('bank', HousePrice, "bought-house") -- 21% Extra house costs
         TriggerEvent('qb-bossmenu:server:addAccountMoney', "realestate", (HousePrice / 100) * math.random(18, 25))
         TriggerEvent('qb-log:server:CreateLog', 'house', Lang:t("log.house_purchased"), 'green', Lang:t("log.house_purchased_by", {house = house:upper(), price = HousePrice, firstname = pData.PlayerData.charinfo.firstname, lastname = pData.PlayerData.charinfo.lastname}))
+        TriggerClientEvent('QBCore:Notify', src, Lang:t("success.house_purchased"), 'success', 5000)
     else
         TriggerClientEvent('QBCore:Notify', source, Lang:t("error.not_enough_money"), "error")
     end
@@ -429,7 +431,11 @@ QBCore.Functions.CreateCallback('qb-houses:server:hasKey', function(source, cb, 
 end)
 
 QBCore.Functions.CreateCallback('qb-houses:server:isOwned', function(source, cb, house)
-    if houseowneridentifier[house] and houseownercid[house] then
+    local src = source
+    local Player = QBCore.Functions.GetPlayer(src)
+    if Player.PlayerData.job.name == "realestate" then
+        cb(true)
+    elseif houseowneridentifier[house] and houseownercid[house] then
         cb(true)
     else
         cb(false)

--- a/server/main.lua
+++ b/server/main.lua
@@ -433,7 +433,7 @@ end)
 QBCore.Functions.CreateCallback('qb-houses:server:isOwned', function(source, cb, house)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    if Player.PlayerData.job.name == "realestate" then
+    if Player and Player.PlayerData and Player.PlayerData.job and Player.PlayerData.job.name == "realestate" then
         cb(true)
     elseif houseowneridentifier[house] and houseownercid[house] then
         cb(true)


### PR DESCRIPTION
To enable qb-target for apartments, change Config.UseTarget to true in config.lua.

See discord for additional notes on this PR.

This PR should not be merged until qb-core:DrawText is merged on master.