### PR TITLE
Added the config option to show property prices on unowned blips

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -919,8 +919,12 @@ RegisterNetEvent('qb-houses:client:setupHouseBlips2', function() -- Setup unowne
             SetBlipScale  (HouseBlip2, 0.65)
             SetBlipAsShortRange(HouseBlip2, true)
             SetBlipColour(HouseBlip2, 3)
-            AddTextEntry('UnownedHouse', Lang:t("info.house_for_sale"))
-            BeginTextCommandSetBlipName('UnownedHouse')
+	    if Config.UnownedBlipsPrices then
+            	AddTextEntry('UnownedHouse', Lang:t("info.house_for_sale").. " $".. v.price)
+            else
+		AddTextEntry('UnownedHouse', Lang:t("info.house_for_sale"))
+            end		
+	    BeginTextCommandSetBlipName('UnownedHouse')
             EndTextCommandSetBlipName(HouseBlip2)
             UnownedHouseBlips[#UnownedHouseBlips+1] = HouseBlip2
         end

--- a/config.lua
+++ b/config.lua
@@ -3,6 +3,7 @@ Config = Config or {}
 Config.MinZOffset = 30
 Config.RamsNeeded = 2
 Config.UnownedBlips = false
+Config.UnownedBlipsPrices = false -- True = Show the price of unowned properties | False = Don't show the price of unowned properties
 
 Config.Houses = {}
 


### PR DESCRIPTION
**Describe Pull request**
First, make sure you've read and are following the contribution guidelines and style guide and your code reflects that.
Write up a clear and concise description of what your pull request adds or fixes and if it's an added feature explain why you think it should be included in the core.
This pr adds the a config option to display property prices in unowned properties blips

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- yes
- Does your code fit the style guidelines? [yes/no]
- yes
- Does your PR fit the contribution guidelines? [yes/no]
- yes
