### PR TITLE
Update for GetHouseStreetCount()

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -121,15 +121,17 @@ end
 exports('hasKey', hasKey)
 
 local function GetHouseStreetCount(street)
-    local count = 1
-    local query = '%' .. street .. '%'
-    local result = MySQL.Sync.fetchAll('SELECT * FROM houselocations WHERE name LIKE ?', {query})
-    if result[1] then
-        for i = 1, #result, 1 do
-            count = count + 1
-        end
-    end
-    return count
+   local housenumber = 1
+	local query = '%' .. street .. '%'
+	local result = MySQL.single.await('SELECT id,label FROM houselocations WHERE label LIKE ? ORDER BY id DESC', {query})
+	if result then
+		local label = result.label
+		local split = QBCore.Shared.SplitStr(label, " ")
+		housenumber = split[#split]+1
+		return housenumber
+	else
+		return housenumber
+	end
 end
 
 local function isHouseOwned(house)


### PR DESCRIPTION
This solves a problem for duplication in addresses.
When wrong/unbought houses get deleted the old function just 'counts' the amount of addresses from that street and generates a number on that value.
E.g.:
Before deletion you have like
- Xx st1
- Xx st2
- Xx st3
You delete Xx st2 and the old functions generates "Xx st3" as new address (but this already exists so a user gets conflicts with keys etc)
New function will search for "Xx st3" and will make "Xx st4" :-)

This function will select the full address last submitted from that street and will increase the last known housenumber by 1.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
