### PR TITLE
:bug: Fix for exit menu disappearing

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -297,8 +297,10 @@ end
 local function DeleteHousesTargets()
     if Config.Targets and next(Config.Targets) then
         for id, target in pairs(Config.Targets) do
-            target.zone:destroy()
-            Config.Targets[id] = nil
+            if not string.find(id, "Exit") then
+                target.zone:destroy()
+                Config.Targets[id] = nil
+            end
         end
     end
 end


### PR DESCRIPTION
**Describe Pull request:**
Fix for exit menu disappearing on invited player relog. Ensures exit target is not deleted on DeleteHousesTargets() function

**If your PR is to fix an issue mention that issue here:**
When first player entered instance and invited another player and the invited player relogged, when the invited player selected to respawn back within the instance, the exit PolyZone would be destroyed 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest) Yes
- Does your code fit the style guidelines? [yes/no] Yes
- Does your PR fit the contribution guidelines? [yes/no] Yes
