### PR TITLE
Get the correct offsets

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -581,7 +581,7 @@ local function LoadDecorations(house)
 						end
 						local decorateObject = CreateObject(modelHash, Config.Houses[house].decorations[k].x, Config.Houses[house].decorations[k].y, Config.Houses[house].decorations[k].z, false, false, false)
 						FreezeEntityPosition(decorateObject, true)
-                        			SetEntityCoordsNoOffset(decorateObject, Config.Houses[house].decorations[k].x, Config.Houses[house].decorations[k].y, Config.Houses[house].decorations[k].z)
+						SetEntityCoordsNoOffset(decorateObject, Config.Houses[house].decorations[k].x, Config.Houses[house].decorations[k].y, Config.Houses[house].decorations[k].z)
 						SetEntityRotation(decorateObject, Config.Houses[house].decorations[k].rotx, Config.Houses[house].decorations[k].roty, Config.Houses[house].decorations[k].rotz)
 						ObjectList[Config.Houses[house].decorations[k].objectId] = {hashname = Config.Houses[house].decorations[k].hashname, x = Config.Houses[house].decorations[k].x, y = Config.Houses[house].decorations[k].y, z = Config.Houses[house].decorations[k].z, rotx = Config.Houses[house].decorations[k].rotx, roty = Config.Houses[house].decorations[k].roty, rotz = Config.Houses[house].decorations[k].rotz, object = decorateObject, objectId = Config.Houses[house].decorations[k].objectId}
 					end
@@ -604,7 +604,7 @@ local function LoadDecorations(house)
 				end
 				local decorateObject = CreateObject(modelHash, Config.Houses[house].decorations[k].x, Config.Houses[house].decorations[k].y, Config.Houses[house].decorations[k].z, false, false, false)
 				FreezeEntityPosition(decorateObject, true)
-                		SetEntityCoordsNoOffset(decorateObject, Config.Houses[house].decorations[k].x, Config.Houses[house].decorations[k].y, Config.Houses[house].decorations[k].z)
+				SetEntityCoordsNoOffset(decorateObject, Config.Houses[house].decorations[k].x, Config.Houses[house].decorations[k].y, Config.Houses[house].decorations[k].z)
 				Config.Houses[house].decorations[k].object = decorateObject
 				SetEntityRotation(decorateObject, Config.Houses[house].decorations[k].rotx, Config.Houses[house].decorations[k].roty, Config.Houses[house].decorations[k].rotz)
 				ObjectList[Config.Houses[house].decorations[k].objectId] = {hashname = Config.Houses[house].decorations[k].hashname, x = Config.Houses[house].decorations[k].x, y = Config.Houses[house].decorations[k].y, z = Config.Houses[house].decorations[k].z, rotx = Config.Houses[house].decorations[k].rotx, roty = Config.Houses[house].decorations[k].roty, rotz = Config.Houses[house].decorations[k].rotz, object = decorateObject, objectId = Config.Houses[house].decorations[k].objectId}

--- a/client/main.lua
+++ b/client/main.lua
@@ -1555,9 +1555,9 @@ RegisterCommand('getoffset', function()
         Config.Houses[CurrentHouse].coords.enter.z - Config.MinZOffset
     )
     if IsInside then
-        local xdist = coords.x - houseCoords.x
-        local ydist = coords.y - houseCoords.y
-        local zdist = coords.z - houseCoords.z
+        local xdist = houseCoords.x - coords.x
+        local ydist = houseCoords.y - coords.y
+        local zdist = houseCoords.z - coords.z
         print('X: '..xdist)
         print('Y: '..ydist)
         print('Z: '..zdist)


### PR DESCRIPTION
Describe Pull request
qb-apartments subtracts the offsets from the base coords and the getoffset command gives an opposite value, you have to change the sign for all the X, Y, Z coordinates before putting them as offsets. It messed with my head for a couple of hours when changing to a different shell.

If your PR is to fix an issue mention that issue here

Questions (please complete the following information):

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] yes
Does your code fit the style guidelines? [yes/no] yes
Does your PR fit the contribution guidelines? [yes/no] yes