### PR TITLE
Keyholder exploit + key hand logs

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1108,10 +1108,12 @@ RegisterNetEvent('qb-houses:client:giveHouseKey', function()
         local pedpos = GetEntityCoords(PlayerPedId())
         local housedist = #(pedpos - vector3(Config.Houses[ClosestHouse].coords.enter.x, Config.Houses[ClosestHouse].coords.enter.y, Config.Houses[ClosestHouse].coords.enter.z))
         if housedist < 10 then
+	if HasHouseKey then
             TriggerServerEvent('qb-houses:server:giveHouseKey', playerId, ClosestHouse)
         else
             QBCore.Functions.Notify(Lang:t("error.no_door"), "error")
         end
+	end
     elseif ClosestHouse == nil then
         QBCore.Functions.Notify(Lang:t("error.no_house"), "error")
     else

--- a/server/main.lua
+++ b/server/main.lua
@@ -317,7 +317,7 @@ RegisterNetEvent('qb-houses:server:giveHouseKey', function(target, house)
             housekeyholders[house][#housekeyholders[house]+1] = tPlayer.PlayerData.citizenid
             MySQL.update('UPDATE player_houses SET keyholders = ? WHERE house = ?', {json.encode(housekeyholders[house]), house})
             TriggerClientEvent('qb-houses:client:refreshHouse', tPlayer.PlayerData.source)
-
+            TriggerEvent("qb-log:server:CreateLog", "houses", "", "red", "**  House keys handed from: " ..GetPlayerName(src).. " ID: "   ..src.. " House: " ..house.. "** To player: " ..GetPlayerName(target).. " ID: "   ..target)
             TriggerClientEvent('QBCore:Notify', tPlayer.PlayerData.source, Lang:t("success.recieved_key", {value = Config.Houses[house].adress}), 'success', 2500)
         else
             local sourceTarget = QBCore.Functions.GetPlayer(src)


### PR DESCRIPTION
Description: 

In my server I've had many people exploit house keys by walking up to a house they have keys to and not interacting with the menu, then walking away and walking up to a door they do not have keys to and handing keys. If they are consistent, they can enter any house first try and steal all the items and remain as keyholders.

I have not tested this in a brand new core, it may be different as qb-menu interaction opens automatically in newest versions of houses, but if you have people exploiting this method, this will fix it and send logs whenever keys are handed

I've only added a check to the client event and a log server side.

-----
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Yes, but not on latest core
- Does your code fit the style guidelines? [yes/no]
- yes?
- Does your PR fit the contribution guidelines? [yes/no]
- yes?
