### PR TITLE
fix(client): Use w for heading to prevent incorrect spawn position

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1065,7 +1065,7 @@ RegisterNetEvent('qb-houses:client:addGarage', function()
             x = pos.x,
             y = pos.y,
             z = pos.z,
-            h = heading,
+            w = heading,
         }
         TriggerServerEvent('qb-houses:server:addGarage', ClosestHouse, coords)
     else


### PR DESCRIPTION
**Describe Pull request**
Since the server sided vehicle spawning update, vehicles being spawned from house garages have been spawning facing the wrong direction. This is because the json for the garage position was using `h` for heading, but the server side spawn function expects a `w` from a `vector4`.  This PR updates the json to replace the `h` with a `w`.

Since existing house garages will already have their position in the database with `h` this PR won't fix existing vehicles and so I have also created the following PR to be merged alongside this one:
https://github.com/qbcore-framework/qb-garages/pull/262

Fixes https://github.com/qbcore-framework/qb-garages/issues/261

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Does your code fit the style guidelines? [yes/no]
- Does your PR fit the contribution guidelines? [yes/no]
