### PR TITLE
Fix: Changes SQL garage default to use "w" for heading

### DIFF
--- a/qb-houses.sql
+++ b/qb-houses.sql
@@ -6,7 +6,7 @@ CREATE TABLE IF NOT EXISTS `houselocations` (
   `owned` tinyint(2) DEFAULT NULL,
   `price` int(11) DEFAULT NULL,
   `tier` tinyint(4) DEFAULT NULL,
-  `garage` text NOT NULL DEFAULT '{"y":0,"x":0,"h":0,"z":0}',
+  `garage` text NOT NULL DEFAULT '{"y":0,"x":0,"w":0,"z":0}',
   PRIMARY KEY (`id`),
   KEY `name` (`name`)
 ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1;


### PR DESCRIPTION
**Describe Pull request**
This PR works with https://github.com/qbcore-framework/qb-garages/pull/344 to fix the issue with errors being spammed relating to the default house garage value using "h" for the heading whereas the code is written to use "w".

Fixes: https://github.com/qbcore-framework/qb-garages/issues/341

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
