### PR TITLE
fix: Prevent garages being updated if no garage set

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -528,6 +528,8 @@ local function SetClosestHouse()
             end, ClosestHouse)
         end
     end
+    
+    if next(Config.Houses[ClosestHouse].garage) == nil then return end
     TriggerEvent('qb-garages:client:setHouseGarage', ClosestHouse, HasHouseKey)
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -1085,8 +1085,9 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     TriggerEvent('qb-houses:client:setupHouseBlips')
     if Config.UnownedBlips then TriggerEvent('qb-houses:client:setupHouseBlips2') end
     Wait(100)
-    TriggerEvent('qb-garages:client:setHouseGarage', ClosestHouse, HasHouseKey)
     TriggerServerEvent('qb-houses:server:setHouses')
+    if next(Config.Houses[ClosestHouse].garage) == nil then return end
+    TriggerEvent('qb-garages:client:setHouseGarage', ClosestHouse, HasHouseKey)
 end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
@@ -1525,7 +1526,9 @@ CreateThread(function()
         TriggerEvent('qb-houses:client:setupHouseBlips2')
     end
     Wait(wait)
-    TriggerEvent('qb-garages:client:setHouseGarage', ClosestHouse, HasHouseKey)
+    if ClosestHouse and next(Config.Houses[ClosestHouse].garage) ~= nil then
+        TriggerEvent('qb-garages:client:setHouseGarage', ClosestHouse, HasHouseKey)
+    end
     TriggerServerEvent('qb-houses:server:setHouses')
 
     while true do


### PR DESCRIPTION
**Describe Pull request**
This PR checks whether the contents of the garage table is empty for houses, if so it won't send the event to qb-garages which prevents it from registering or searching the database for a house garage.


**Questions (please complete the following information):**
- [x] Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- [x] Does your code fit the style guidelines? [yes/no]
- [x] Does your PR fit the contribution guidelines? [yes/no]
