### PR TITLE
fix: Extra house checks when indexing

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -529,7 +529,7 @@ local function SetClosestHouse()
         end
     end
     
-    if next(Config.Houses[ClosestHouse].garage) == nil then return end
+    if ClosestHouse and next(Config.Houses[ClosestHouse].garage) == nil then return end
     TriggerEvent('qb-garages:client:setHouseGarage', ClosestHouse, HasHouseKey)
 end
 
@@ -1086,7 +1086,7 @@ AddEventHandler('QBCore:Client:OnPlayerLoaded', function()
     if Config.UnownedBlips then TriggerEvent('qb-houses:client:setupHouseBlips2') end
     Wait(100)
     TriggerServerEvent('qb-houses:server:setHouses')
-    if next(Config.Houses[ClosestHouse].garage) == nil then return end
+    if ClosestHouse and next(Config.Houses[ClosestHouse].garage) == nil then return end
     TriggerEvent('qb-garages:client:setHouseGarage', ClosestHouse, HasHouseKey)
 end)
 


### PR DESCRIPTION
**Describe Pull request**
This PR relates to PR https://github.com/qbcore-framework/qb-houses/pull/250 and adds extra checks to prevent any issues when trying to access `garage` in the event that `ClosestHouse` is nil. This is to check whether a house exists as well as just checking if a garage exists.

**Questions (please complete the following information):**
- [x] Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- [x] Does your code fit the style guidelines? [yes/no]
- [x] Does your PR fit the contribution guidelines? [yes/no]
